### PR TITLE
set default value for enums with a UNSPECIFIED option

### DIFF
--- a/pkl/crossplane.contrib/CompositionResponse.pkl
+++ b/pkl/crossplane.contrib/CompositionResponse.pkl
@@ -41,7 +41,7 @@ class ResponseMeta {
 /// A Result of running a Function.
 class Result {
   /// Severity of this result.
-  severity: Severity
+  severity: Severity = SEVERITY_UNSPECIFIED
 
   /// Human-readable details about the result.
   message: String

--- a/pkl/crossplane.contrib/Resource.pkl
+++ b/pkl/crossplane.contrib/Resource.pkl
@@ -34,7 +34,7 @@ typealias Ready = Int(isBetween(0,2))
 ///
 ///   - A Function should not set this field in a RunFunctionResponse to indicate
 ///     that the desired composite resource is ready. This will be ignored.
-ready: Ready?
+ready: Ready? = READY_UNSPECIFIED
 
 /// The resource's connection details.
 ///


### PR DESCRIPTION

### Description of your changes
Quality of life improvement of Result.severity now defaulting to SEVERITY_UNSPECIFIED, as well as Resource.Ready defaults now to READY_UNSPECIFIED.
<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

I have:

- [x] Read and followed Crossplane's [contribution process].
- ~[ ] Added or updated unit tests for my change.~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
