### PR TITLE
version of pkl packages is now inferred from env variables

### DIFF
--- a/.github/workflows/pkl.yml
+++ b/.github/workflows/pkl.yml
@@ -10,14 +10,14 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
-        with:
-          fetch-tags: true
       - name: Setup Pkl
         uses: pkl-community/setup-pkl@v0
         with:
           pkl-version: 0.26.1
       - name: Login to GH
         run: echo ${{ github.token }} | gh auth login --with-token
+      - name: Fetch Tags
+        run: git fetch --tags
       - name: Get Tag Name
         run: echo "TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
       - name: Package and Create GitHub Release

--- a/.github/workflows/pkl.yml
+++ b/.github/workflows/pkl.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          fetch-tags: true
       - name: Setup Pkl
         uses: pkl-community/setup-pkl@v0
         with:

--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,6 @@ pkl-release: check-tag pkl-package
 	-t ${TAG} \
 	-n "" \
 	--target ${TARGET} \
-	--prerelease \
-	--draft \
 	$(RELEASE_FILES)
 
 .PHONY: build-image

--- a/README.md
+++ b/README.md
@@ -64,10 +64,15 @@ $ crossplane xpkg build -f package --embed-runtime-image=runtime
 $ crossplane xpkg push -f function-pkl*.xpkg ghcr.io/crossplane-contrib/function-pkl
 
 # Resolve Pkl Project Dependencies
-$ pkl project resolve ./pkl/*/
+$ make pkl-resolve
 
 # Package the Pkl Project
-$ pkl project package ./pkl/*/
+$ make pkl-package
+
+# Release a Pkl Project
+$ git tag crossplane.contrib@x.y.z
+$ git push --tags
+$ make pkl-release TAG=crossplane.contrib@x.y.z
 
 # Debugging this function
 # While a Debugging session is running run on the same host:

--- a/pkl/crossplane.contrib.example/PklProject
+++ b/pkl/crossplane.contrib.example/PklProject
@@ -17,15 +17,18 @@
 /// Templates for configuring [Kubernetes](https://kubernetes.io).
 amends "pkl:Project"
 
+local repo = read?("env:REPOSITORY") ?? "github.com/crossplane-contrib/function-pkl"
+local packageVersion: String = read?("env:CROSSPLANE_CONTRIB_EXAMPLE_VERSION") ?? "0.0.0"
+
 package {
   name = "crossplane.contrib.example"
   authors {
     "Tim Geimer <32556895+Avarei@users.noreply.github.com>"
   }
-  version = "1.0.0"
-  baseUri = "package://pkg.pkl-lang.org/github.com/crossplane-contrib/function-pkl/\(name)"
-  packageZipUrl = "https://github.com/crossplane-contrib/function-pkl/releases/download/\(name)@\(version)/\(name)@\(version).zip"
-  sourceCode = "https://github.com/crossplane-contrib/function-pkl"
+  version = packageVersion
+  baseUri = "package://pkg.pkl-lang.org/\(repo)/\(name)"
+  packageZipUrl = "https://\(repo)/releases/download/\(name)@\(version)/\(name)@\(version).zip"
+  sourceCode = "https://\(repo)"
   license = "Apache-2.0"
   description = """
     Example for using the [Composition Functions](https://docs.crossplane.io/latest/concepts/composition-functions/).
@@ -36,7 +39,7 @@ dependencies {
   ["crossplane.contrib.xrd"] = import("../crossplane.contrib.xrd/PklProject")
 
   ["k8s"] {
-    uri = "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1"
+    uri = "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.1.0"
   }
   ["k8s.contrib.crd"] {
     uri = "package://pkg.pkl-lang.org/pkl-pantry/k8s.contrib.crd@1.0.7"

--- a/pkl/crossplane.contrib.example/PklProject.deps.json
+++ b/pkl/crossplane.contrib.example/PklProject.deps.json
@@ -45,9 +45,9 @@
     },
     "package://pkg.pkl-lang.org/pkl-k8s/k8s@1": {
       "type": "remote",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-k8s/k8s@1.1.0",
       "checksums": {
-        "sha256": "75c6d66d94c335417a3c502e107aaeadf7a60b4e1d34b2c979afe11193205a1a"
+        "sha256": "9ca6002419e405a19b517d506490b46be9279556b5ef2664be0e836df80535e5"
       }
     },
     "package://pkg.pkl-lang.org/github.com/crossplane-contrib/function-pkl/crossplane.contrib.xrd@1": {

--- a/pkl/crossplane.contrib.xrd/PklProject
+++ b/pkl/crossplane.contrib.xrd/PklProject
@@ -17,14 +17,15 @@
 /// Templates for configuring [Kubernetes](https://kubernetes.io).
 amends "pkl:Project"
 
-local repo = "github.com/crossplane-contrib/function-pkl"
+local repo = read?("env:REPOSITORY") ?? "github.com/crossplane-contrib/function-pkl"
+local packageVersion: String = read?("env:CROSSPLANE_CONTRIB_XRD_VERSION") ?? "0.0.0"
 
 package {
   name = "crossplane.contrib.xrd"
   authors {
     "Tim Geimer <32556895+Avarei@users.noreply.github.com>"
   }
-  version = "1.0.0"
+  version = packageVersion
   baseUri = "package://pkg.pkl-lang.org/\(repo)/\(name)"
   packageZipUrl = "https://\(repo)/releases/download/\(name)@\(version)/\(name)@\(version).zip"
   sourceCode = "https://\(repo)"
@@ -43,5 +44,5 @@ dependencies {
   ["syntax"] { uri = "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.syntax@1.0.2" }
   ["openapiv3"] { uri = "package://pkg.pkl-lang.org/pkl-pantry/org.openapis.v3@2.1.1" }
 
-  ["k8s"] { uri = "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1" }
+  ["k8s"] { uri = "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.1.0" }
 }

--- a/pkl/crossplane.contrib.xrd/PklProject.deps.json
+++ b/pkl/crossplane.contrib.xrd/PklProject.deps.json
@@ -38,9 +38,9 @@
     },
     "package://pkg.pkl-lang.org/pkl-k8s/k8s@1": {
       "type": "remote",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-k8s/k8s@1.1.0",
       "checksums": {
-        "sha256": "75c6d66d94c335417a3c502e107aaeadf7a60b4e1d34b2c979afe11193205a1a"
+        "sha256": "9ca6002419e405a19b517d506490b46be9279556b5ef2664be0e836df80535e5"
       }
     },
     "package://pkg.pkl-lang.org/pkl-pantry/org.openapis.v3@2": {

--- a/pkl/crossplane.contrib/PklProject
+++ b/pkl/crossplane.contrib/PklProject
@@ -17,15 +17,18 @@
 /// Templates for configuring [Kubernetes](https://kubernetes.io).
 amends "pkl:Project"
 
+local repo = read?("env:REPOSITORY") ?? "github.com/crossplane-contrib/function-pkl"
+local packageVersion: String = read?("env:CROSSPLANE_CONTRIB_VERSION") ?? "0.0.0"
+
 package {
   name = "crossplane.contrib"
   authors {
     "Tim Geimer <32556895+Avarei@users.noreply.github.com>"
   }
-  version = "1.0.0"
-  baseUri = "package://pkg.pkl-lang.org/github.com/crossplane-contrib/function-pkl/\(name)"
-  packageZipUrl = "https://github.com/crossplane-contrib/function-pkl/releases/download/\(name)@\(version)/\(name)@\(version).zip"
-  sourceCode = "https://github.com/crossplane-contrib/function-pkl"
+  version = packageVersion
+  baseUri = "package://pkg.pkl-lang.org/\(repo)/\(name)"
+  packageZipUrl = "https://\(repo)/releases/download/\(name)@\(version)/\(name)@\(version).zip"
+  sourceCode = "https://\(repo)"
   license = "Apache-2.0"
   description = """
     Templates for reading and configuring [Composition Functions](https://docs.crossplane.io/latest/concepts/composition-functions/).
@@ -33,6 +36,6 @@ package {
 }
 dependencies {
   ["k8s"] {
-    uri = "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1"
+    uri = "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.1.0"
   }
 }

--- a/pkl/crossplane.contrib/PklProject.deps.json
+++ b/pkl/crossplane.contrib/PklProject.deps.json
@@ -3,9 +3,9 @@
   "resolvedDependencies": {
     "package://pkg.pkl-lang.org/pkl-k8s/k8s@1": {
       "type": "remote",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-k8s/k8s@1.1.0",
       "checksums": {
-        "sha256": "75c6d66d94c335417a3c502e107aaeadf7a60b4e1d34b2c979afe11193205a1a"
+        "sha256": "9ca6002419e405a19b517d506490b46be9279556b5ef2664be0e836df80535e5"
       }
     }
   }


### PR DESCRIPTION
make pkl-resolve and make pkl-release now read the latest git tag for each package to determine the version without being stored in the PklProject files update Kubernetes Dependencies

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes # 

I have:

- [x] Read and followed Crossplane's [contribution process].
- ~[ ] Added or updated unit tests for my change.~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
